### PR TITLE
Prevent the process from crashing on request error

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,12 @@ async function scrape (url, opts) {
       resolve(unfurled)
       parser.end()
     })
+
+    req.on('error', (err) => {
+      debug('request failed', err.message)
+      reject(err)
+      parser.end()
+    })
   })
 }
 


### PR DESCRIPTION
Hi,

I'm using `unfurled` in a project of mine but it keeps crashing my server process whenever I hand it a broken link (issue #9). This commit fixes it.